### PR TITLE
Patch to have PDL::PP calculate the size of z and allocate work for you

### DIFF
--- a/lib/PDL/Opt/QP.pd
+++ b/lib/PDL/Opt/QP.pd
@@ -216,7 +216,6 @@ sub qp_orig {
   croak("Value of meq is invalid!")
     if ($meq > $q) || ($meq < 0 );
 
-  my $iter = zeros(2);               # Store info about interations
   my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
 
   #  Pars => 'dmat(m,m); dvec(m);
@@ -225,7 +224,7 @@ sub qp_orig {
   #      int [o]iact(q); int [o]nact();
   #      int [o]iter(s=2); [t] work(z); int [io]ierr();
 
-  my ( $sol, $lagr, $crval, $iact, $nact ) = qpgen2(
+  my ( $sol, $lagr, $crval, $iact, $nact, $iter ) = qpgen2(
                    $Dmat->copy, $dvec->copy,
                    $Amat->transpose->copy,
                    $avec->copy,
@@ -294,7 +293,6 @@ sub qp {
   croak("dimmension check failed: A_neq [n x p] and a_neq [p* x 1]")
     if $a_neq->nelem != $p;
 
-  my $iter = zeros(2);               # Store info about interations
   my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
 
   my $A = $A_eq->glue( 0, $A_neq )->copy;
@@ -307,7 +305,7 @@ sub qp {
   #      int [o]iact(q); int [o]nact();
   #      int [o]iter(s=2); [t] work(z); int [io]ierr();
 
-  my ( $sol, $lagr, $crval, $iact, $nact ) = qpgen2(
+  my ( $sol, $lagr, $crval, $iact, $nact, $iter ) = qpgen2(
                    $Dmat->copy, $dvec->copy,
                    $A->transpose->copy,
                    $a->copy,

--- a/lib/PDL/Opt/QP.pd
+++ b/lib/PDL/Opt/QP.pd
@@ -128,7 +128,7 @@ pp_def("qpgen2",
         [o]sol(m); [o]lagr(q); [o]crval();
         amat(m,q); bvec(q); int meq();
         int [o]iact(q); int [o]nact();
-        int [o]iter(s=2); [t] work(z); int [io]ierr();
+        int [o]iter(s=2); [t] work(z); int [o]ierr();
     ',
     RedoDimsCode => pp_line_numbers(__LINE__, q{
         /* Calculate z */
@@ -153,8 +153,12 @@ pp_def("qpgen2",
 		
 		int m_size = $SIZE(m);
 		int q_size = $SIZE(q);
+		int factor_and_output_err;
 		
         threadloop %{
+			/* set the factor input to zero to indicate that the intput isn't
+			 * factored. */
+			factor_and_output_err = 0;
             qpgen2_(
                 $P(dmat),
                 $P(dvec),
@@ -172,8 +176,10 @@ pp_def("qpgen2",
                 $P(nact),
                 $P(iter),
                 $P(work),
-                $P(ierr)
+                &factor_and_output_err
             );
+            /* Store the error results */
+            $ierr() = factor_and_output_err;
         %}
     }),
     Doc => q{
@@ -216,20 +222,19 @@ sub qp_orig {
   croak("Value of meq is invalid!")
     if ($meq > $q) || ($meq < 0 );
 
-  my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
+  #my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
 
   #  Pars => 'dmat(m,m); dvec(m);
   #      [o]sol(m); [o]lagr(q); [o]crval();
   #      amat(m,q); bvec(q); int meq();
   #      int [o]iact(q); int [o]nact();
-  #      int [o]iter(s=2); [t] work(z); int [io]ierr();
+  #      int [o]iter(s=2); [t] work(z); int [o]ierr();
 
-  my ( $sol, $lagr, $crval, $iact, $nact, $iter ) = qpgen2(
+  my ( $sol, $lagr, $crval, $iact, $nact, $iter, $ierr ) = qpgen2(
                    $Dmat->copy, $dvec->copy,
                    $Amat->transpose->copy,
                    $avec->copy,
                    $meq,
-                   $ierr
         );
 
   croak "qp: constraints are inconsistent, no solution!"
@@ -293,7 +298,7 @@ sub qp {
   croak("dimmension check failed: A_neq [n x p] and a_neq [p* x 1]")
     if $a_neq->nelem != $p;
 
-  my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
+  #my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
 
   my $A = $A_eq->glue( 0, $A_neq )->copy;
   my $a = $a_eq->glue( 0, $a_neq )->copy;  # ->flat?
@@ -305,12 +310,11 @@ sub qp {
   #      int [o]iact(q); int [o]nact();
   #      int [o]iter(s=2); [t] work(z); int [io]ierr();
 
-  my ( $sol, $lagr, $crval, $iact, $nact, $iter ) = qpgen2(
+  my ( $sol, $lagr, $crval, $iact, $nact, $iter, $ierr ) = qpgen2(
                    $Dmat->copy, $dvec->copy,
                    $A->transpose->copy,
                    $a->copy,
                    $meq,
-                   $ierr
         );
 
   croak "qp: constraints are inconsistent, no solution!"

--- a/lib/PDL/Opt/QP.pd
+++ b/lib/PDL/Opt/QP.pd
@@ -128,8 +128,18 @@ pp_def("qpgen2",
         [o]sol(m); [o]lagr(q); [o]crval();
         amat(m,q); bvec(q); int fdamat(); int q(); int meq();
         int [o]iact(q); int [o]nact();
-        int [o]iter(s=2); work(z); int [io]ierr();
+        int [o]iter(s=2); [t] work(z); int [io]ierr();
     ',
+    RedoDimsCode => pp_line_numbers(__LINE__, q{
+        /* Calculate z */
+		int m_size = $PDL(dmat)->dims[0];
+		int q_size = $PDL(amat)->dims[1];
+		
+		/* r = max(n, q) */
+		int r_size = m_size < q_size ? q_size : m_size;
+		
+		$SIZE(z) = 2*m_size + r_size*(r_size+5)/2 + 2*q_size + 1;
+    }),
     GenericTypes => [D],
     Code => '
         extern int qpgen2_(
@@ -208,11 +218,11 @@ sub qp_orig {
 
   # my $iact = zeros($q);              # Store which constraints are active
   # my $nact = pdl(0);                 # Store number of active constraints
-  my $r    = $n < $q ? $n : $q;      # Used to size work space
+  # my $r    = $n < $q ? $n : $q;      # Used to size work space
   # my $sol  = zeros($n->sclr);        # Store the solution [n]
   # my $lagr = zeros($q->sclr);        # Store the Lagranges for the constraints
   # my $crval= pdl(0);                 # Value at min
-  my $work = zeros((2*$n+$r*($r+5)/2+2*$q+1)->sclr);  # Work space
+  # my $work = zeros((2*$n+$r*($r+5)/2+2*$q+1)->sclr);  # Work space
   my $iter = zeros(2);               # Store info about interations
   my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
 
@@ -239,7 +249,7 @@ sub qp_orig {
                    $q, $meq,
                    # $iact, $nact,
                    # $iter,
-                   $work,
+                   # $work,
                    $ierr
         );
 
@@ -306,11 +316,11 @@ sub qp {
 
   # my $iact = zeros($q);              # Store which constraints are active
   # my $nact = pdl(0);                 # Store number of active constraints
-  my $r    = $n < $q ? $n : $q;      # Used to size work space
+  # my $r    = $n < $q ? $n : $q;      # Used to size work space
   # my $sol  = zeros($n->sclr);        # Store the solution [n]
   # my $lagr = zeros($q->sclr);        # Store the Lagranges for the constraints
   # my $crval= pdl(0);                 # Value at min
-  my $work = zeros((2*$n+$r*($r+5)/2+2*$q+1)->sclr);  # Work space
+  #my $work = zeros((2*$n+$r*($r+5)/2+2*$q+1)->sclr);  # Work space
   my $iter = zeros(2);               # Store info about interations
   my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
 
@@ -340,7 +350,7 @@ sub qp {
                    $q, $meq,
                    # $iact, $nact,
                    # $iter,
-                   $work,
+                   # $work,
                    $ierr
         );
 

--- a/lib/PDL/Opt/QP.pd
+++ b/lib/PDL/Opt/QP.pd
@@ -265,39 +265,42 @@ sub qp_orig {
 EOD
 
 pp_add_exported('', 'qp');
-pp_addpm({At=>'Bot'},<<'EOD');
+pp_addpm pp_line_numbers(__LINE__, q{
 
 sub qp {
-  my ($Dmat, $dvec, $A_eq, $a_eq, $A_neq, $a_neq) = @_;
+  my ($Dmat, $dvec, %args) = @_;
 
   my $col = 0;
   my $row = 1;
 
   my $n = pdl $Dmat->dim($row);    # D is an [n x n] matrix
+  
+  # Default handling for A_eq and A_neq
+  my $A_eq  = exists $args{A_eq}  ? $args{A_eq}  : zeroes(0, $n);
+  my $A_neq = exists $args{A_neq} ? $args{A_neq} : zeroes(0, $n);
+  
   my $m = pdl $A_eq->dim($col);    # A is an [n x m] matrix
   my $p = pdl $A_neq->dim($col);    # A is an [n x p] matrix
-  my $q = $m + $p;    # A is an [n x q] matrix
 
-  if( $A_eq->isnull ){ $A_eq = zeros(0,$n); }
-  if( $a_eq->isnull ){ $a_eq = zeros(1,$m); }
-  if( $A_neq->isnull ){ $A_neq = zeros(0,$n); }
-  if( $a_neq->isnull ){ $a_neq = zeros(1,$p); }
+  # Default handling for a_eq and a_neq
+  my $a_eq  = exists $args{a_eq}  ? $args{a_eq}  : zeroes($m);
+  my $a_neq = exists $args{a_neq} ? $args{a_neq} : zeroes($p);
+  
+#  croak("dimmension check failed: Dmat [n x n*] is not square")
+#    if $Dmat->dim($col) != $n;
+#  croak("dimmension check failed: Dmat [n x n] and dvec [n* x 1]")
+#    if $dvec->nelem != $n;
+#  croak("dimmension check failed: A_eq [n* x m] and a_eq [n x 1]")
+#    if $A_eq->dim($row) != $n;
+#  croak("dimmension check failed: A_eq [n x m] and a_eq [m* x 1]")
+#    if $a_eq->nelem != $m;
+#  croak("dimmension check failed: A_neq [n* x p] and a_neq [p x 1]")
+#    if $A_neq->dim($row) != $n;
+#  croak("dimmension check failed: A_neq [n x p] and a_neq [p* x 1]")
+#    if $a_neq->nelem != $p; # why can't I say 
 
-  croak("dimmension check failed: Dmat [n x n*] is not square")
-    if $Dmat->dim($col) != $n;
-  croak("dimmension check failed: Dmat [n x n] and dvec [n* x 1]")
-    if $dvec->nelem != $n;
-  croak("dimmension check failed: A_eq [n* x m] and a_eq [n x 1]")
-    if $A_eq->dim($row) != $n;
-  croak("dimmension check failed: A_eq [n x m] and a_eq [m* x 1]")
-    if $a_eq->nelem != $m;
-  croak("dimmension check failed: A_neq [n* x p] and a_neq [p x 1]")
-    if $A_neq->dim($row) != $n;
-  croak("dimmension check failed: A_neq [n x p] and a_neq [p* x 1]")
-    if $a_neq->nelem != $p;
-
-  my $A = $A_eq->glue( 0, $A_neq )->copy;
-  my $a = $a_eq->glue( 0, $a_neq )->copy;  # ->flat?
+  my $A = $A_eq->glue( 0, $A_neq );
+  my $a = $a_eq->glue( 0, $a_neq );
   my $meq = $A_eq->dim(0);
 
   #  Pars => 'dmat(m,m); dvec(m);
@@ -340,7 +343,7 @@ sub qp {
   #      Lagrangian = res1$lagr,
   #      iact=res1$iact[1:res1$nact])   
 }
-EOD
+});
 
 pp_addpm({At=>'Bot'},<<'EOD');
 

--- a/lib/PDL/Opt/QP.pd
+++ b/lib/PDL/Opt/QP.pd
@@ -222,8 +222,6 @@ sub qp_orig {
   croak("Value of meq is invalid!")
     if ($meq > $q) || ($meq < 0 );
 
-  #my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
-
   #  Pars => 'dmat(m,m); dvec(m);
   #      [o]sol(m); [o]lagr(q); [o]crval();
   #      amat(m,q); bvec(q); int meq();
@@ -238,10 +236,10 @@ sub qp_orig {
         );
 
   croak "qp: constraints are inconsistent, no solution!"
-      if $ierr->sclr == 1;
+      if any($ierr == 1);
   croak "qp: matrix D in quadratic function is not positive definite!"
-      if $ierr->sclr == 2;
-  croak "qp: some problem with mininization" if $ierr->sclr;
+      if any($ierr == 2);
+  croak "qp: some problem with mininization" if any($ierr);
 
   return {
     x     => $sol,
@@ -298,8 +296,6 @@ sub qp {
   croak("dimmension check failed: A_neq [n x p] and a_neq [p* x 1]")
     if $a_neq->nelem != $p;
 
-  #my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
-
   my $A = $A_eq->glue( 0, $A_neq )->copy;
   my $a = $a_eq->glue( 0, $a_neq )->copy;  # ->flat?
   my $meq = $A_eq->dim(0);
@@ -318,10 +314,10 @@ sub qp {
         );
 
   croak "qp: constraints are inconsistent, no solution!"
-      if $ierr->sclr == 1;
+      if any($ierr == 1);
   croak "qp: matrix D in quadratic function is not positive definite!"
-      if $ierr->sclr == 2;
-  croak "qp: some problem with mininization" if $ierr->sclr;
+      if any($ierr == 2);
+  croak "qp: some problem with mininization" if any($ierr);
 
   return {
     x     => $sol,

--- a/lib/PDL/Opt/QP.pd
+++ b/lib/PDL/Opt/QP.pd
@@ -124,9 +124,9 @@ EOD
 
 pp_def("qpgen2",
     HandleBad => 0,
-    Pars => 'dmat(m,m); dvec(m); int fddmat(); int n();
+    Pars => 'dmat(m,m); dvec(m);
         [o]sol(m); [o]lagr(q); [o]crval();
-        amat(m,q); bvec(q); int fdamat(); int q(); int meq();
+        amat(m,q); bvec(q); int meq();
         int [o]iact(q); int [o]nact();
         int [o]iter(s=2); [t] work(z); int [io]ierr();
     ',
@@ -141,7 +141,7 @@ pp_def("qpgen2",
 		$SIZE(z) = 2*m_size + r_size*(r_size+5)/2 + 2*q_size + 1;
     }),
     GenericTypes => [D],
-    Code => '
+    Code => pp_line_numbers(__LINE__, q{
         extern int qpgen2_(
             double *dmat, double *dvec, integer *fddmat, integer *n,
 
@@ -150,32 +150,32 @@ pp_def("qpgen2",
             integer *iact, integer *nact, integer *iter, double *work,
             integer *ierr
         );
-
-        qpgen2_(
-            $P(dmat),
-            $P(dvec),
-            $P(fddmat),
-            $P(n),
-            $P(sol),
-            $P(lagr),
-            $P(crval),
-            $P(amat),
-            $P(bvec),
-            $P(fdamat),
-            $P(q),
-            $P(meq),
-            $P(iact),
-            $P(nact),
-            $P(iter),
-            $P(work),
-            $P(ierr)
-        );
-
-        // Not sure if we will need to process the solutions here
-        // for (i = 0; i < $SIZE(n); i++)
-        //  $x(n=>i) = xtmp[i];
-        // $maxit()=it;
-',
+		
+		int m_size = $SIZE(m);
+		int q_size = $SIZE(q);
+		
+        threadloop %{
+            qpgen2_(
+                $P(dmat),
+                $P(dvec),
+                &m_size,
+                &m_size,
+                $P(sol),
+                $P(lagr),
+                $P(crval),
+                $P(amat),
+                $P(bvec),
+                &m_size,
+                &q_size,
+                $P(meq),
+                $P(iact),
+                $P(nact),
+                $P(iter),
+                $P(work),
+                $P(ierr)
+            );
+        %}
+    }),
     Doc => q{
 
 =for ref
@@ -216,40 +216,20 @@ sub qp_orig {
   croak("Value of meq is invalid!")
     if ($meq > $q) || ($meq < 0 );
 
-  # my $iact = zeros($q);              # Store which constraints are active
-  # my $nact = pdl(0);                 # Store number of active constraints
-  # my $r    = $n < $q ? $n : $q;      # Used to size work space
-  # my $sol  = zeros($n->sclr);        # Store the solution [n]
-  # my $lagr = zeros($q->sclr);        # Store the Lagranges for the constraints
-  # my $crval= pdl(0);                 # Value at min
-  # my $work = zeros((2*$n+$r*($r+5)/2+2*$q+1)->sclr);  # Work space
   my $iter = zeros(2);               # Store info about interations
   my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
 
-  # print "\$A = ", $Amat;
-  # print "\$a = $avec\n";
-  # print "n = $n\n";
-  # print "q = $q\n";
-  # print "meq = $meq\n";
-
-  # Pars => 'dmat(m,m); dvec(m); int fddmat(); int n();
-  #     [o]sol(m); [o]lagr(q); [o]crval();
-  #     amat(m,q); bvec(q); int fdamat(); int q(); int meq();
-  #     int [o]iact(q); int [o]nact();
-  #     int [o]iter(s=2); work(z); int [io]ierr();
-  # ',
+  #  Pars => 'dmat(m,m); dvec(m);
+  #      [o]sol(m); [o]lagr(q); [o]crval();
+  #      amat(m,q); bvec(q); int meq();
+  #      int [o]iact(q); int [o]nact();
+  #      int [o]iter(s=2); [t] work(z); int [io]ierr();
 
   my ( $sol, $lagr, $crval, $iact, $nact ) = qpgen2(
                    $Dmat->copy, $dvec->copy,
-                   $n, $n,
-                   # $sol, $lagr,
-                   # $crval,
                    $Amat->transpose->copy,
-                   $avec->copy, $n,
-                   $q, $meq,
-                   # $iact, $nact,
-                   # $iter,
-                   # $work,
+                   $avec->copy,
+                   $meq,
                    $ierr
         );
 
@@ -314,13 +294,6 @@ sub qp {
   croak("dimmension check failed: A_neq [n x p] and a_neq [p* x 1]")
     if $a_neq->nelem != $p;
 
-  # my $iact = zeros($q);              # Store which constraints are active
-  # my $nact = pdl(0);                 # Store number of active constraints
-  # my $r    = $n < $q ? $n : $q;      # Used to size work space
-  # my $sol  = zeros($n->sclr);        # Store the solution [n]
-  # my $lagr = zeros($q->sclr);        # Store the Lagranges for the constraints
-  # my $crval= pdl(0);                 # Value at min
-  #my $work = zeros((2*$n+$r*($r+5)/2+2*$q+1)->sclr);  # Work space
   my $iter = zeros(2);               # Store info about interations
   my $ierr = pdl(0);                 # Input: 1=Factorized; Output: error flag
 
@@ -328,29 +301,17 @@ sub qp {
   my $a = $a_eq->glue( 0, $a_neq )->copy;  # ->flat?
   my $meq = $A_eq->dim(0);
 
-  # print "\$A = ", $A;
-  # print "\$a = $a\n";
-  # print "n = $n\n";
-  # print "q = $q\n";
-  # print "meq = $meq\n";
-
-  # Pars => 'dmat(m,m); dvec(m); int fddmat(); int n();
-  #     [o]sol(m); [o]lagr(q); [o]crval();
-  #     amat(m,q); bvec(q); int fdamat(); int q(); int meq();
-  #     int [o]iact(q); int [o]nact();
-  #     int [o]iter(s=2); work(z); int [io]ierr();
+  #  Pars => 'dmat(m,m); dvec(m);
+  #      [o]sol(m); [o]lagr(q); [o]crval();
+  #      amat(m,q); bvec(q); int meq();
+  #      int [o]iact(q); int [o]nact();
+  #      int [o]iter(s=2); [t] work(z); int [io]ierr();
 
   my ( $sol, $lagr, $crval, $iact, $nact ) = qpgen2(
                    $Dmat->copy, $dvec->copy,
-                   $n, $n,
-                   # $sol, $lagr,
-                   # $crval,
                    $A->transpose->copy,
-                   $a->copy, $n,
-                   $q, $meq,
-                   # $iact, $nact,
-                   # $iter,
-                   # $work,
+                   $a->copy,
+                   $meq,
                    $ierr
         );
 

--- a/t/solve-qp.t
+++ b/t/solve-qp.t
@@ -15,11 +15,8 @@ my $dmat = pdl q[ 0.0100 0.0018 0.0011 ;
                   0.0011 0.0026 0.0199 ];
 my $dvec = zeros(3);
 my $amat = $mu      # mu' x = mu_0
-  ->glue( 0, ones( 1, 3 ) )    # 1'  x = 1    (sum(x) = 1)
-  ->copy;
-my $avec = pdl($mu_0)->glue( 0, ones(1) )->copy;
-my $bmat = null;
-my $bvec = null;
+  ->glue( 0, ones( 1, 3 ) );    # 1'  x = 1    (sum(x) = 1)
+my $avec = pdl($mu_0, 1);
 
 {
     # diag "n    = ", $mu->nelem;
@@ -30,15 +27,15 @@ my $bvec = null;
     # diag "bmat = ", $bmat;
     # diag "bvec = ", $bvec;
 
-    my $sol = qp( $dmat, $dvec, $amat, $avec, $bmat, $bvec );
+    my $sol = qp( $dmat, $dvec, A_eq => $amat, a_eq => $avec);
     my $expected_sol = pdl [ 0.82745456, -0.090746123, 0.26329157 ];
     ok( all( approx $sol->{x}, $expected_sol, 1e-8), "Got expected solution" )
       or diag "Got $sol->{x}\nExpected: $expected_sol";
 }
 
 {
-    $bmat = $bmat->glue( 0, identity(3) );
-    $bvec = $bvec->glue( 0, zeros(3) )->flat;
+    my $bmat = identity(3);
+    my $bvec = zeros(3);
 
     # diag "n    = ", $mu->nelem;
     # diag "dmat = ", $dmat;
@@ -48,7 +45,8 @@ my $bvec = null;
     # diag "bmat'= ", $bmat->transpose;
     # diag "bvec = ", $bvec;
 
-    my $sol = qp( $dmat, $dvec, $amat, $avec, $bmat, $bvec );
+    my $sol = qp( $dmat, $dvec, A_eq => $amat, a_eq => $avec,
+        A_neq => $bmat, a_neq => $bvec );
     my $expected_sol = pdl [ 1, 0, 0 ];
     ok( all( approx $sol->{x}, $expected_sol, 1e-8), "Got expected solution" )
       or diag "Got $sol->{x}\nExpected: $expected_sol";


### PR DESCRIPTION
This reduces the complexity of the perl-side wrapper functions. I think there's more that can be cleaned out. I don't think this'll change any of the success or failure, but it does isolate the z calculations for us.
